### PR TITLE
fix missing destination

### DIFF
--- a/templates/backup_point.erb
+++ b/templates/backup_point.erb
@@ -1,1 +1,1 @@
-backup	<%= @client_user %>@<%= @host %>:<%= @source_path.gsub(/\/$/, '') %>/<%= "\t" %>
+backup	<%= @client_user %>@<%= @host %>:<%= @source_path.gsub(/\/$/, '') %>/<%= "\t" %><%= "\t\t." %>


### PR DESCRIPTION
in `templates/backup_point.erb`, there was no destination specified like there is in `templates/config.erb`, this made rsnapshot fail with the following error:
```
[root@rsnapshot-int.prod.dmaes.be ~]# /etc/rsnapshot/scripts/rsnapshot_backup.sh daily
----------------------------------------------------------------------------
rsnapshot encountered an error! The program was invoked with these options:
/usr/bin/rsnapshot -c /etc/rsnapshot/mysql-01.prod.dmaes.be-rsnapshot.conf \
    daily 
----------------------------------------------------------------------------
ERROR: /etc/rsnapshot/mysql-01.prod.dmaes.be-rsnapshot.conf on line 86:
ERROR: backup rsnapshot@mysql-01.prod.dmaes.be:/srv/mysql_backups/ - no \
         destination path specified for backup point 
ERROR: ---------------------------------------------------------------------
ERROR: Errors were found in /etc/rsnapshot/mysql-01.prod.dmaes.be-rsnapshot.conf,
ERROR: rsnapshot can not continue. If you think an entry looks right, make
ERROR: sure you don't have spaces where only tabs should be.
```