### PR TITLE
Add delaycompress to logrotate config

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -33,6 +33,7 @@ class rsnapshot::server(
   $rsnapshot_logrotate = @(EOF)
   <%= @log_path %>/*.log {
     compress
+    delaycompress
     missingok
     monthly
     rotate 3


### PR DESCRIPTION
This PR adds `delaycompress` to the logrotate config. The first rotated file will therefore be suffixed with `.log.1` and can still be parsed without decompression commands. Helpful for scripts parsing/analyzing the log file, including recently rotated log files.