### PR TITLE
Add Manual Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This module is a fork of tedivm/rsnapshot, and has many enhancements, including:
 
 Working Puppet Master and PuppetDB assumed for all automated functionality.
 
+Manual mode allows simple configuration of clients and servers without need of PuppetDB.
+
 > rsnapshot is a filesystem snapshot utility based on rsync. rsnapshot makes it
 easy to make periodic snapshots of local machines, and remote machines over ssh.
 The code makes extensive use of hard links whenever possible, to greatly reduce
@@ -112,6 +114,8 @@ Defaults to 10pm nightly, Sunday 10am for weekly and the first of the month at 8
   to be installed on the backup server.
 * Multiple puppet runs (client, then server, then client again) need to occur
   for all resources to be created on both servers.
+* Manual mode requires neither PuppetDB nor Storeconfigs, but SSH keys must be
+  configured manually and client configs must be created for the server manually.
 
 ### Beginning with rsnapshot
 
@@ -161,6 +165,27 @@ class { 'rsnapshot::server':
 }
 ```
 
+For 'manual mode', set `manual_mode => true` and add client definitions:
+
+```
+rsnapshot::server::config { '<fqdn.of.client.host>':
+ directories => [
+  '/etc',
+  '/home',
+ ],
+}
+```
+
+In hiera this looks like:
+
+```
+rsnapshot::server::manual_mode: true
+rsnapshot::server::config:
+ 'fqdn.of.client.host':
+  directories:
+   - '/home'
+   - '/root'
+```
 
 ### Configuring the Client
 
@@ -207,6 +232,12 @@ class { 'rsnapshot::client':
   push_ssh_key        => true,
   wrapper_path        => '/opt/rsnapshot_wrappers/',
 }
+```
+
+For manual mode, set `manual_mode => true` and add a value for the server key:
+
+```
+server_rsnapshot_key => 'command="/opt/rsnapshot_wrappers/rsync_sudo.sh",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty,from="<ip.of.your.server>" ssh-rsa <public key material>'
 ```
 
 # Back Up Pre and Post Actions

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -24,6 +24,7 @@ class rsnapshot::client (
   $excludes             = {},
   $include_files        = {},
   $includes             = {},
+  $manual_mode          = $rsnapshot::params::manual_mode,
   $one_fs               = $rsnapshot::params::one_fs,
   $push_ssh_key         = $rsnapshot::params::push_ssh_key,
   $purge_ssh_keys       = $rsnapshot::params::purge_ssh_keys,
@@ -33,6 +34,7 @@ class rsnapshot::client (
   $retain_weekly        = $rsnapshot::params::retain_weekly,
   $rsync_long_args      = $rsnapshot::params::rsync_long_args,
   $rsync_short_args     = $rsnapshot::params::rsync_short_args,
+  $server_rsnapshot_key = $rsnapshot::params::server_rsnapshot_key,
   $server_user          = $rsnapshot::params::server_user,
   $setup_sudo           = $rsnapshot::params::setup_sudo,
   $ssh_args             = $rsnapshot::params::ssh_args,
@@ -47,9 +49,11 @@ class rsnapshot::client (
   # Add User
   class { 'rsnapshot::client::user' :
     client_user    => $client_user,
+    manual_mode    => $manual_mode,
     push_ssh_key   => $push_ssh_key,
     purge_ssh_keys => $purge_ssh_keys, 
     server         => $server,
+    server_rsnapshot_key    => $server_rsnapshot_key,
     server_user    => $server_user,
     setup_sudo     => $setup_sudo,
     use_sudo       => $use_sudo,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -19,7 +19,7 @@ class rsnapshot::client (
   $cmd_wrapper_postexec = [],
   $cmd_wrapper_preexec  = [],
   $connect_endpoint     = $rsnapshot::params::connect_endpoint,
-  $directories          = ['/etc','/home','/root','/var/www','/opt/mysqldumps'],
+  $directories          = $rsnapshot::params::directories,
   $exclude_files        = {},
   $excludes             = {},
   $include_files        = {},
@@ -48,16 +48,16 @@ class rsnapshot::client (
 
   # Add User
   class { 'rsnapshot::client::user' :
-    client_user    => $client_user,
-    manual_mode    => $manual_mode,
-    push_ssh_key   => $push_ssh_key,
-    purge_ssh_keys => $purge_ssh_keys, 
-    server         => $server,
-    server_rsnapshot_key    => $server_rsnapshot_key,
-    server_user    => $server_user,
-    setup_sudo     => $setup_sudo,
-    use_sudo       => $use_sudo,
-    wrapper_path   => $wrapper_path_normalized,
+    client_user          => $client_user,
+    manual_mode          => $manual_mode,
+    push_ssh_key         => $push_ssh_key,
+    purge_ssh_keys       => $purge_ssh_keys,
+    server               => $server,
+    server_rsnapshot_key => $server_rsnapshot_key,
+    server_user          => $server_user,
+    setup_sudo           => $setup_sudo,
+    use_sudo             => $use_sudo,
+    wrapper_path         => $wrapper_path_normalized,
   }
 
   # Add Wrapper Scripts

--- a/manifests/client/user.pp
+++ b/manifests/client/user.pp
@@ -56,7 +56,7 @@ class rsnapshot::client::user (
       require => File["/home/${client_user}/.ssh"],
     }
     # manual mode: read hiera instead of facts
-    if $manual_mode == true {
+    if $manual_mode {
       Concat::Fragment { "${server}_pubkey":
         target  => "/home/${client_user}/.ssh/authorized_keys",
         content => "${server_rsnapshot_key}",

--- a/manifests/client/user.pp
+++ b/manifests/client/user.pp
@@ -1,9 +1,11 @@
 # Defined class rsnapshot::client::user
 class rsnapshot::client::user (
   $client_user          = '',
+  $manual_mode          = $rsnapshot::params::manual_mode,
   $push_ssh_key         = true,
   $purge_ssh_keys       = false,
   $server               = '',
+  $server_rsnapshot_key = $rsnapshot::params::server_rsnapshot_key,
   $server_user          = '',
   $setup_sudo           = true,
   $use_sudo             = true,
@@ -53,7 +55,15 @@ class rsnapshot::client::user (
       group   => $client_user,
       require => File["/home/${client_user}/.ssh"],
     }
-    Concat::Fragment <<|tag=="${server}_rsnapshot_server_key"|>>
+    # manual mode: read hiera instead of facts
+    if $manual_mode == true {
+      Concat::Fragment { "${server}_pubkey":
+        target  => "/home/${client_user}/.ssh/authorized_keys",
+        content => "${server_rsnapshot_key}",
+      }
+    } else {
+      Concat::Fragment <<|tag=="${server}_rsnapshot_server_key"|>>
+    }
   }
 
   ## Add sudo config if needed.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class rsnapshot::params {
   $cmd_postexec           = undef
   $cmd_preexec            = undef
   $connect_endpoint       = $facts['networking']['fqdn']
+  $directories            = ['/etc','/home','/root','/var/www','/opt/mysqldumps']
   $du_args                = '-csh'
   $link_dest              = 1
   $log_level              = 'warning'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class rsnapshot::params {
   $du_args                = '-csh'
   $link_dest              = 1
   $log_level              = 'warning'
+  $manual_mode            = false
   $no_create_root         = 0
   $one_fs                 = undef
   $push_ssh_key           = true
@@ -31,6 +32,7 @@ class rsnapshot::params {
   $server_config_path     = '/etc/rsnapshot'
   $server_log_path        = '/var/log/rsnapshot'
   $server_packages        = [ 'rsnapshot' ]
+  $server_rsnapshot_key   = undef
   $server_user            = 'root'
   $setup_sudo             = true
   $ssh_args               = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,6 +10,7 @@ class rsnapshot::server(
   $lock_path                                         = $rsnapshot::params::lock_path,
   $log_level                                         = $rsnapshot::params::log_level,
   $log_path                                          = $rsnapshot::params::server_log_path,
+  $manual_mode                                       = $rsnapshot::params::manual_mode,
   $no_create_root                                    = $rsnapshot::params::no_create_root,
   Variant[String, Enum['linux','windows']] $platform = 'linux',
   $rsync_numtries                                    = $rsnapshot::params::rsync_numtries,
@@ -77,22 +78,74 @@ class rsnapshot::server(
     owner  => $server_user,
   }
 
-  Rsnapshot::Server::Config <<| server == "${facts['networking']['fqdn']}" |>> {
-    backup_path            => $::rsnapshot::server::backup_path,
-    config_path            => $::rsnapshot::server::config_path,
-    du_args                => $::rsnapshot::server::du_args,
-    link_dest              => $::rsnapshot::server::link_dest,
-    lock_path              => $::rsnapshot::server::lock_path,
-    loglevel               => $::rsnapshot::server::log_level,
-    log_path               => $::rsnapshot::server::log_path,
-    no_create_root         => $::rsnapshot::server::no_create_root,
-    require                => File[$config_path],
-    rsync_numtries         => $::rsnapshot::server::rsync_numtries,
-    server_user            => $server_user,
-    stop_on_stale_lockfile => $::rsnapshot::server::stop_on_stale_lockfile,
-    sync_first             => $::rsnapshot::server::sync_first,
-    use_lazy_deletes       => $::rsnapshot::server::use_lazy_deletes,
-    verbose                => $::rsnapshot::server::verbose,
+  # manual_mode: avoid use of PuppetDB and storeconfigs
+  if $manual_mode {
+    $client_settings = lookup('rsnapshot::server::config',Hash,hash,{})
+    $client_settings.keys.each |$item| {
+      $defaults = {
+        backup_path             => $rsnapshot::server::backup_path,
+        config_path             => $rsnapshot::server::config_path,
+        du_args                 => $rsnapshot::server::du_args,
+        link_dest               => $rsnapshot::server::link_dest,
+        lock_path               => $rsnapshot::server::lock_path,
+        loglevel                => $rsnapshot::server::log_level,
+        log_path                => $rsnapshot::server::log_path,
+        no_create_root          => $rsnapshot::server::no_create_root,
+        require                 => File[$config_path],
+        rsync_numtries          => $rsnapshot::server::rsync_numtries,
+        server_user             => $server_user,
+        stop_on_stale_lockfile  => $rsnapshot::server::stop_on_stale_lockfile,
+        sync_first              => $rsnapshot::server::sync_first,
+        use_lazy_deletes        => $rsnapshot::server::use_lazy_deletes,
+        verbose                 => $rsnapshot::server::verbose,
+        backup_hourly_cron      => $rsnapshot::server::backup_hourly_cron,
+        backup_time_dom         => $rsnapshot::server::backup_time_dom,
+        backup_time_hour        => $rsnapshot::server::backup_time_hour,
+        backup_time_minute      => $rsnapshot::server::backup_time_minute,
+        backup_time_weekday     => $rsnapshot::server::backup_time_weekday,
+        client_user             => $rsnapshot::server::client_user,
+        cmd_postexec            => $rsnapshot::server::cmd_postexec,
+        cmd_preexec             => $rsnapshot::server::cmd_preexec,
+        connect_endpoint        => $item,
+        directories             => $rsnapshot::server::directories,
+        exclude_files           => [],
+        excludes                => [],
+        include_files           => [],
+        includes                => [],
+        one_fs                  => $rsnapshot::server::one_fs,
+        retain_daily            => $rsnapshot::server::retain_daily,
+        retain_hourly           => $rsnapshot::server::retain_hourly,
+        retain_monthly          => $rsnapshot::server::retain_monthly,
+        retain_weekly           => $rsnapshot::server::retain_weekly,
+        rsync_long_args         => $rsnapshot::server::rsync_long_args,
+        rsync_short_args        => $rsnapshot::server::rsync_short_args,
+        server                  => "${facts['networking']['fqdn']}",
+        ssh_args                => $rsnapshot::server::ssh_args,
+        use_sudo                => $rsnapshot::server::use_sudo,
+        wrapper_path            => $rsnapshot::params::wrapper_path,
+      }
+      Rsnapshot::Server::Config { $item:
+        * => ($defaults + $client_settings[$item]),
+      }
+    }
+  } else {
+    Rsnapshot::Server::Config <<| server == "${facts['networking']['fqdn']}" |>> {
+      backup_path            => $::rsnapshot::server::backup_path,
+      config_path            => $::rsnapshot::server::config_path,
+      du_args                => $::rsnapshot::server::du_args,
+      link_dest              => $::rsnapshot::server::link_dest,
+      lock_path              => $::rsnapshot::server::lock_path,
+      loglevel               => $::rsnapshot::server::log_level,
+      log_path               => $::rsnapshot::server::log_path,
+      no_create_root         => $::rsnapshot::server::no_create_root,
+      require                => File[$config_path],
+      rsync_numtries         => $::rsnapshot::server::rsync_numtries,
+      server_user            => $server_user,
+      stop_on_stale_lockfile => $::rsnapshot::server::stop_on_stale_lockfile,
+      sync_first             => $::rsnapshot::server::sync_first,
+      use_lazy_deletes       => $::rsnapshot::server::use_lazy_deletes,
+      verbose                => $::rsnapshot::server::verbose,
+    }
   }
 
   ## Export rsnapshot server values for client trust

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,7 +50,8 @@ class rsnapshot::server(
     replace => true,
   }
 
-  file { '/etc/cron.daily/logrotate': ensure => absent}
+  # conflicts with another module
+  #file { '/etc/cron.daily/logrotate': ensure => absent}
 
 
   # Add logging folder

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -101,5 +101,5 @@ exclude	<%= value %>
 ###############################
 
 <% @directories.each do |source_dir| -%>
-backup	<%= @client_user %>@<%= @connect_endpoint,trim_mode: "" %>:<%= source_dir.gsub(/\/$/, '') %>/<%= "\t" %><%= "\t\t." %>
+backup	<%= @client_user %>@<%= @connect_endpoint %>:<%= source_dir.gsub(/\/$/, '') %>/<%= "\t" %><%= "\t\t." %>
 <% end -%>


### PR DESCRIPTION
We use neither PuppetDB nor Storeconfigs but we really like the way you handle SSH keys and client configs in this module. So we added an option 'manual_mode' to enable us to use it.

There are three other minor mods:

In 'manifests/client.pp' we put the default values for '$directories' in '$rsnapshot::params::directories'.

In 'manifests/server.pp' we commented out line 167, ensure '/etc/cron.daily/logrotate' is absent, because it conflicts with another Puppet module we use. Not sure how you would like to handle this.

In 'templates/config.erb' we modified line 104 slightly, because '.trim_mode' was not recognized by our setup. Not sure how you would like to handle this one either.